### PR TITLE
fix(fetch-ensure): handles 5xx errors with an empty response.

### DIFF
--- a/packages/belt-fetch/src/fetch-ensure.spec.ts
+++ b/packages/belt-fetch/src/fetch-ensure.spec.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 import { fetchEnsure } from './index';
 import * as http from 'http';
 
@@ -30,6 +30,12 @@ describe('fetchEnsure', () => {
           } else if (req.url.startsWith('/throw/custom')) {
             res.writeHead(401, { 'Content-Type': 'application/custom' });
             res.write(JSON.stringify({ message: 'Error!' }));
+          } else if (req.url.startsWith('/crash/502')) {
+            res.writeHead(502);
+          } else if (req.url.startsWith('/crash/533')) {
+            res.writeHead(533, '');
+          } else if (req.url.startsWith('/crash/boom')) {
+            res.destroy();
           }
         } else {
           res.writeHead(404, { 'Content-Type': 'application/json' });
@@ -119,6 +125,38 @@ describe('fetchEnsure', () => {
       } catch (error) {
         assert.ok(error);
         assert.strictEqual((error as any).message, 'Error!');
+      }
+    });
+  });
+
+  describe('crash', () => {
+    it('throw text', async () => {
+      const resp = await fetch('http://127.0.0.1:3030/crash/502');
+      assert.strictEqual(resp.status, 502);
+      try {
+        await fetchEnsure(resp);
+      } catch (error) {
+        assert.strictEqual(error, 'Bad Gateway');
+      }
+    });
+
+    it('throw 533 (special)', async () => {
+      const resp = await fetch('http://127.0.0.1:3030/crash/533');
+      assert.strictEqual(resp.status, 533);
+      try {
+        await fetchEnsure(resp);
+      } catch (error) {
+        assert.strictEqual(error, 'HTTP error 533');
+      }
+    });
+
+    it('throw boom, closed connection', async () => {
+      try {
+        await fetch('http://127.0.0.1:3030/crash/boom');
+        throw new Error('Must failed!');
+      } catch (error) {
+        assert.ok(error);
+        assert.strictEqual((error as any).message, 'fetch failed');
       }
     });
   });

--- a/packages/belt-fetch/src/fetch-format-payload.ts
+++ b/packages/belt-fetch/src/fetch-format-payload.ts
@@ -20,6 +20,9 @@ export async function fetchFormatPayload(response: Response, contentTypes: Fetch
     }
   }
 
-  // default
+  if (!response.status || response.status >= 500) {
+    return (await response.text()) || response.statusText || `HTTP error ${response.status}`;
+  }
+
   return await response.text();
 }


### PR DESCRIPTION
Avoid 5xx empty response.