### PR TITLE
feat(mutate-error-with-ref): setAsEnumerable options

### DIFF
--- a/packages/belt-error/README.md
+++ b/packages/belt-error/README.md
@@ -30,6 +30,18 @@ const error = new Error('An error!');
 
 (error as RefError).refError; // E-XXXXXXX
 (error as RefError).message;  // E-XXXXXXX - [message]
+// Beware `message` and `stack` are not enumerable in Error object
+Object.keys(error); // ['refError']
+
+
+// You can set (danger zone) the properties as enumerable:
+const error = new Error('An error!', {
+  setAsEnumerable: true,
+});
+(error as RefError).refError; // E-XXXXXXX
+(error as RefError).message;  // E-XXXXXXX - [message]
+
+Object.keys(error); // ['stack', 'message', 'refError']
 ```
 
 ## getErrorMessage

--- a/packages/belt-error/src/mutate-error-with-ref.spec.ts
+++ b/packages/belt-error/src/mutate-error-with-ref.spec.ts
@@ -9,6 +9,19 @@ describe('mutate-error-with-ref', () => {
     assert.strictEqual(mutateError.message, 'Toto');
     assert.strictEqual(mutateError, error);
     assert.ok(mutateError.refError);
+    assert.deepStrictEqual(Object.keys(mutateError), ['refError']);
+  });
+
+  it('Set message/stack enumerable', () => {
+    const error = new Error('Toto');
+    const mutateError = mutateErrorWithRef(error, {
+      setAsEnumerable: true,
+    });
+    assert.strictEqual(error.message, 'Toto');
+    assert.strictEqual(mutateError.message, 'Toto');
+    assert.strictEqual(mutateError, error);
+    assert.ok(mutateError.refError);
+    assert.deepStrictEqual(Object.keys(mutateError), ['stack', 'message', 'refError']);
   });
 
   it('Mutate an object', () => {
@@ -17,6 +30,7 @@ describe('mutate-error-with-ref', () => {
     assert.strictEqual(error.message, 'Toto');
     assert.strictEqual(mutateError.message, 'Toto');
     assert.ok(mutateError.refError);
+    assert.deepStrictEqual(Object.keys(mutateError), ['refError']);
   });
 
   it('Mutate with identifier', () => {
@@ -28,6 +42,7 @@ describe('mutate-error-with-ref', () => {
     assert.ok(mutateError.refError);
     assert.ok(mutateError.refError.startsWith('E-'));
     assert.ok(mutateError.refError.endsWith('5c'));
+    assert.deepStrictEqual(Object.keys(mutateError), ['refError']);
   });
 
   it('Mutate, prefix ref in message', () => {
@@ -38,6 +53,7 @@ describe('mutate-error-with-ref', () => {
     assert.strictEqual(mutateError, error);
     assert.ok(mutateError.refError);
     assert.ok(mutateError.message.startsWith(mutateError.refError));
+    assert.deepStrictEqual(Object.keys(mutateError), ['refError']);
   });
 
   it('Mutate with empty message', () => {
@@ -48,6 +64,7 @@ describe('mutate-error-with-ref', () => {
     assert.strictEqual(mutateError, error);
     assert.ok(mutateError.refError);
     assert.ok(mutateError.message.startsWith(mutateError.refError));
+    assert.deepStrictEqual(Object.keys(mutateError), ['refError']);
   });
 
   it('Mutate two times', () => {
@@ -60,6 +77,7 @@ describe('mutate-error-with-ref', () => {
     assert.strictEqual(refError, mutateError2.refError);
     assert.ok(mutateError.refError);
     assert.ok(mutateError.message.startsWith(mutateError.refError));
+    assert.deepStrictEqual(Object.keys(mutateError), ['refError']);
   });
 
   it('Mutate and add properties', () => {
@@ -78,6 +96,7 @@ describe('mutate-error-with-ref', () => {
     assert.strictEqual(mutateError.tenant, 'yolo');
     assert.strictEqual(mutateError.user, 'maurice');
     assert.ok(mutateError.message.startsWith(mutateError.refError));
+    assert.deepStrictEqual(Object.keys(mutateError), ['refError', 'tenant', 'user']);
   });
 
   it('More than 4095 errors', () => {
@@ -97,6 +116,7 @@ describe('mutate-error-with-ref', () => {
       assert.strictEqual(mutateError.tenant, 'yolo');
       assert.strictEqual(mutateError.user, 'maurice');
       assert.ok(mutateError.message.startsWith(mutateError.refError));
+      assert.deepStrictEqual(Object.keys(mutateError), ['refError', 'tenant', 'user']);
     }
   });
 });

--- a/packages/belt-error/src/mutate-error-with-ref.ts
+++ b/packages/belt-error/src/mutate-error-with-ref.ts
@@ -19,6 +19,8 @@ export function mutateErrorWithRef<T, D extends Record<string, unknown>>(
     prefixWithRef?: boolean;
     /** Data that will be injected into the error object */
     data?: D;
+    /** Set `message` and `stack` properties to enumerable */
+    setAsEnumerable?: boolean;
   } = {}
 ): RefError<T & D> {
   const err: RefError<T & D> = asError(error) as RefError<T & D>;
@@ -39,5 +41,19 @@ export function mutateErrorWithRef<T, D extends Record<string, unknown>>(
     }
   }
 
+  if (options.setAsEnumerable) {
+    if (err.message) {
+      Object.defineProperty(err, 'message', {
+        value: err.message,
+        enumerable: true,
+      });
+    }
+    if (err.stack) {
+      Object.defineProperty(err, 'stack', {
+        value: err.stack,
+        enumerable: true,
+      });
+    }
+  }
   return err;
 }


### PR DESCRIPTION
```typescript
// You can set (danger zone) the properties as enumerable:
const error = new Error('An error!', {
  setAsEnumerable: true,
});
(error as RefError).refError; // E-XXXXXXX
(error as RefError).message;  // E-XXXXXXX - [message]

Object.keys(error); // ['stack', 'message', 'refError']
```