### PR TITLE
Feat `memory-cache` convertKey options

### DIFF
--- a/packages/belt-memory-cache/README.md
+++ b/packages/belt-memory-cache/README.md
@@ -23,6 +23,8 @@ const cache = new MemoryCache({
   cleanupIntervalMinutes: 5,
   // If true, values will be cloned before being stored in the cache. -> default: true
   cloneValues: true,
+  // Convert the key before storing it in the cache. -> default: (key) => key
+  convertKey: (key: unknown) => key,
 });
 // The cache will remove all expired items every 5 minutes
 cache.start();

--- a/packages/belt-memory-cache/src/i-memory-cache.ts
+++ b/packages/belt-memory-cache/src/i-memory-cache.ts
@@ -1,7 +1,7 @@
 /**
  * Memory cache
  */
-export interface IMemoryCache {
+export interface IMemoryCache<KeyType = string> {
   /**
    * Start periodic cleanup.
    */
@@ -15,22 +15,22 @@ export interface IMemoryCache {
   /**
    * Add an item to the cache with an expiration time.
    */
-  set<T = unknown>(key: string, value: T, ttlInSeconds: number): void;
+  set<T = unknown>(key: KeyType, value: T, ttlInSeconds: number): void;
 
   /**
    * Get an item from the cache. Returns undefined if the item is expired.
    */
-  get<T = unknown>(key: string): T | undefined;
+  get<T = unknown>(key: KeyType): T | undefined;
 
   /**
    * Check if a key is present in the cache and not expired.
    */
-  has(key: string): boolean;
+  has(key: KeyType): boolean;
 
   /**
    * Delete an item from the cache.
    */
-  delete(key: string): void;
+  delete(key: KeyType): void;
 
   /**
    * Clear the cache.

--- a/packages/belt-memory-cache/src/memory-cache-options.ts
+++ b/packages/belt-memory-cache/src/memory-cache-options.ts
@@ -1,7 +1,7 @@
 /**
  * Options for the memory cache.
  */
-export type MemoryCacheOptions = {
+export type MemoryCacheOptions<KeyType = string> = {
   /**
    * The interval in minutes at which the cache will be cleaned up.
    */
@@ -18,5 +18,5 @@ export type MemoryCacheOptions = {
   /**
    * Convert the cache key
    */
-  convertKey?: (key: string) => string;
+  convertKey?: (key: KeyType) => string;
 };

--- a/packages/belt-memory-cache/src/memory-cache-options.ts
+++ b/packages/belt-memory-cache/src/memory-cache-options.ts
@@ -14,4 +14,9 @@ export type MemoryCacheOptions = {
    * @default true
    */
   cloneValues?: boolean;
+
+  /**
+   * Convert the cache key
+   */
+  convertKey?: (key: string) => string;
 };

--- a/packages/belt-memory-cache/src/memory-cache.spec.ts
+++ b/packages/belt-memory-cache/src/memory-cache.spec.ts
@@ -87,4 +87,30 @@ describe('memory-cache', function () {
       });
     });
   });
+
+  it('Get object id -> key', async () => {
+    const something = { id: 'key' };
+    const cache = new MemoryCache<{
+      id: string;
+    }>({
+      convertKey: (key: { id: string }) => key.id,
+    });
+    cache.set(something, 'value', 1);
+    assert.strictEqual(cache.has(something), true);
+    await setTimeout(1000);
+    assert.strictEqual(cache.has(something), false);
+  });
+
+  it('Get object without id -> key', async () => {
+    const something = { something: 'key', else: 'other' };
+    const somethingElse = { something: 'key2', else: 'other2' };
+    const cache = new MemoryCache<Record<string, unknown>>({
+      convertKey: (key: Record<string, unknown>) => createHash('sha256').update(JSON.stringify(key)).digest('hex'),
+    });
+    cache.set(something, 'value', 1);
+    assert.strictEqual(cache.has(something), true);
+    assert.strictEqual(cache.has(somethingElse), false);
+    await setTimeout(1000);
+    assert.strictEqual(cache.has(something), false);
+  });
 });

--- a/packages/belt-memory-cache/src/memory-cache.spec.ts
+++ b/packages/belt-memory-cache/src/memory-cache.spec.ts
@@ -28,7 +28,7 @@ describe('memory-cache', function () {
       it('expired -> should set and get undefined', async () => {
         const cache = new MemoryCache(config.options);
         cache.set('key', 'value', 1);
-        await setTimeout(1000);
+        await setTimeout(2000);
         assert.strictEqual(cache.get('key'), undefined);
       });
 
@@ -60,7 +60,7 @@ describe('memory-cache', function () {
         const cache = new MemoryCache(config.options);
         cache.set('key', 'value', 1);
         assert.strictEqual(cache.has('key'), true);
-        await setTimeout(1000);
+        await setTimeout(2000);
         assert.strictEqual(cache.has('key'), false);
       });
 
@@ -97,7 +97,7 @@ describe('memory-cache', function () {
     });
     cache.set(something, 'value', 1);
     assert.strictEqual(cache.has(something), true);
-    await setTimeout(1000);
+    await setTimeout(1500);
     assert.strictEqual(cache.has(something), false);
   });
 
@@ -110,7 +110,7 @@ describe('memory-cache', function () {
     cache.set(something, 'value', 1);
     assert.strictEqual(cache.has(something), true);
     assert.strictEqual(cache.has(somethingElse), false);
-    await setTimeout(1000);
+    await setTimeout(1500);
     assert.strictEqual(cache.has(something), false);
   });
 });

--- a/packages/belt-memory-cache/src/memory-cache.spec.ts
+++ b/packages/belt-memory-cache/src/memory-cache.spec.ts
@@ -2,73 +2,89 @@
  * @vitest-environment node
  */
 import { describe, it, assert } from 'vitest';
-import { MemoryCache } from './index';
+import { MemoryCache, type MemoryCacheOptions } from './index';
 import { setTimeout } from 'node:timers/promises';
+import { createHash } from 'node:crypto';
 
 describe('memory-cache', function () {
-  it('should set and get values', function () {
-    const cache = new MemoryCache();
-    cache.set('key', 'value', 1);
-    assert.strictEqual(cache.get('key'), 'value');
-  });
+  (
+    [
+      { title: 'Default options', options: {} },
+      {
+        title: 'With convertKey',
+        options: {
+          convertKey: (key: string) => createHash('sha256').update(key).digest('hex'),
+        },
+      },
+    ] as Array<{ options: MemoryCacheOptions; title: string }>
+  ).forEach(config => {
+    describe('Options ' + config.title, function () {
+      it('should set and get values', function () {
+        const cache = new MemoryCache(config.options);
+        cache.set('key', 'value', 1);
+        assert.strictEqual(cache.get('key'), 'value');
+      });
 
-  it('expired -> should set and get undefined', async () => {
-    const cache = new MemoryCache();
-    cache.set('key', 'value', 1);
-    await setTimeout(1000);
-    assert.strictEqual(cache.get('key'), undefined);
-  });
+      it('expired -> should set and get undefined', async () => {
+        const cache = new MemoryCache(config.options);
+        cache.set('key', 'value', 1);
+        await setTimeout(1000);
+        assert.strictEqual(cache.get('key'), undefined);
+      });
 
-  it('set, delete & get values', function () {
-    const cache = new MemoryCache();
-    cache.set('key', 'value', 1);
-    cache.delete('key');
-    assert.strictEqual(cache.get('key'), undefined);
-  });
+      it('set, delete & get values', function () {
+        const cache = new MemoryCache(config.options);
+        cache.set('key', 'value', 1);
+        cache.delete('key');
+        assert.strictEqual(cache.get('key'), undefined);
+      });
 
-  it('set, multiple delete & get values', function () {
-    const cache = new MemoryCache();
-    cache.set('key', 'value', 1);
-    cache.delete('key');
-    cache.delete('key');
-    cache.delete('key');
-    assert.strictEqual(cache.get('key'), undefined);
-  });
+      it('set, multiple delete & get values', function () {
+        const cache = new MemoryCache(config.options);
+        cache.set('key', 'value', 1);
+        cache.delete('key');
+        cache.delete('key');
+        cache.delete('key');
+        assert.strictEqual(cache.get('key'), undefined);
+      });
 
-  it('set, has, multiple delete & has', function () {
-    const cache = new MemoryCache();
-    cache.set('key', 'value', 1);
-    assert.strictEqual(cache.has('key'), true);
-    cache.delete('key');
-    assert.strictEqual(cache.has('key'), false);
-  });
+      it('set, has, multiple delete & has', function () {
+        const cache = new MemoryCache(config.options);
+        cache.set('key', 'value', 1);
+        assert.strictEqual(cache.has('key'), true);
+        cache.delete('key');
+        assert.strictEqual(cache.has('key'), false);
+      });
 
-  it('set, has, expired, has', async () => {
-    const cache = new MemoryCache();
-    cache.set('key', 'value', 1);
-    assert.strictEqual(cache.has('key'), true);
-    await setTimeout(1000);
-    assert.strictEqual(cache.has('key'), false);
-  });
+      it('set, has, expired, has', async () => {
+        const cache = new MemoryCache(config.options);
+        cache.set('key', 'value', 1);
+        assert.strictEqual(cache.has('key'), true);
+        await setTimeout(1000);
+        assert.strictEqual(cache.has('key'), false);
+      });
 
-  it('garbage collection', async () => {
-    const cache = new MemoryCache({
-      cleanupIntervalMinutes: 0.01,
+      it('garbage collection', async () => {
+        const cache = new MemoryCache({
+          ...config.options,
+          cleanupIntervalMinutes: 0.01,
+        });
+        try {
+          cache.start();
+          for (let i = 0; i < 100; i++) {
+            cache.set('key' + i, 'value', 2);
+          }
+          for (let i = 0; i < 100; i++) {
+            assert.strictEqual(cache.has('key' + i), true);
+          }
+          await setTimeout(2000);
+          for (let i = 0; i < 100; i++) {
+            assert.strictEqual(cache.has('key' + i), false);
+          }
+        } finally {
+          cache.stop();
+        }
+      });
     });
-    try {
-      cache.start();
-      for (let i = 0; i < 100; i++) {
-        cache.set('key' + i, 'value', 2);
-      }
-      for (let i = 0; i < 100; i++) {
-        assert.strictEqual(cache.has('key' + i), true);
-      }
-      await setTimeout(2000);
-      for (let i = 0; i < 100; i++) {
-        assert.strictEqual(cache.has('key' + i), false);
-      }
-    } finally {
-      cache.stop();
-    }
   });
 });

--- a/packages/belt-memory-cache/src/memory-cache.ts
+++ b/packages/belt-memory-cache/src/memory-cache.ts
@@ -5,7 +5,7 @@ import type { MemoryCacheOptions } from './memory-cache-options';
 /**
  * Memory cache
  */
-export class MemoryCache implements IMemoryCache {
+export class MemoryCache<KeyType = string> implements IMemoryCache<KeyType> {
   /**
    * Cache object
    */
@@ -25,9 +25,9 @@ export class MemoryCache implements IMemoryCache {
   /**
    * Convert the cache key
    */
-  private _convertKey: ((key: string) => string) | undefined;
+  private _convertKey: ((key: KeyType) => string) | undefined;
 
-  constructor(options: MemoryCacheOptions = {}) {
+  constructor(options: MemoryCacheOptions<KeyType> = {}) {
     const { cleanupIntervalMinutes = 5, cloneValues = true } = options;
     this._convertKey = options.convertKey;
 
@@ -40,8 +40,8 @@ export class MemoryCache implements IMemoryCache {
   /**
    * @inheritdoc
    */
-  public set<T = unknown>(key: string, value: T, ttlInSeconds: number): void {
-    this._cache[this._convertKey ? this._convertKey(key) : key] = {
+  public set<T = unknown>(key: KeyType, value: T, ttlInSeconds: number): void {
+    this._cache[this._convertKey ? this._convertKey(key) : <string>key] = {
       value: this._cloneValues ? this._deepCopy<T>(value) : value,
       expiredAt: Date.now() + ttlInSeconds * 1000,
     };
@@ -50,8 +50,8 @@ export class MemoryCache implements IMemoryCache {
   /**
    * @inheritdoc
    */
-  public get<T = unknown>(key: string): T | undefined {
-    const formattedKey = this._convertKey ? this._convertKey(key) : key;
+  public get<T = unknown>(key: KeyType): T | undefined {
+    const formattedKey = this._convertKey ? this._convertKey(key) : <string>key;
     const cachedItem = this._cache[formattedKey];
     if (!cachedItem) {
       return undefined;
@@ -74,8 +74,8 @@ export class MemoryCache implements IMemoryCache {
   /**
    * @inheritdoc
    */
-  public has(key: string): boolean {
-    const formattedKey = this._convertKey ? this._convertKey(key) : key;
+  public has(key: KeyType): boolean {
+    const formattedKey = this._convertKey ? this._convertKey(key) : <string>key;
     const cachedItem = this._cache[formattedKey];
     if (!cachedItem) {
       return false;
@@ -96,8 +96,8 @@ export class MemoryCache implements IMemoryCache {
   /**
    * @inheritdoc
    */
-  public delete(key: string): void {
-    const formattedKey = this._convertKey ? this._convertKey(key) : key;
+  public delete(key: KeyType): void {
+    const formattedKey = this._convertKey ? this._convertKey(key) : <string>key;
     if (this._cache[formattedKey]) {
       delete this._cache[formattedKey];
     }


### PR DESCRIPTION
```typescript
import { createHash } from 'node:crypto';
const cache = new MemoryCache({
  convertKey: (key: string) => createHash('sha256').update(key).digest('hex'),
});
cache.set('key', 'value', 1);
assert.strictEqual(cache.get('key'), 'value');
 ```