### PR TITLE
new ignoreCase option; new _ignoreCaseGetValue

### DIFF
--- a/packages/belt-interpolation/src/interpolation.spec.ts
+++ b/packages/belt-interpolation/src/interpolation.spec.ts
@@ -1,84 +1,84 @@
 /**
  * @vitest-environment node
  */
-import { assert, describe, it } from "vitest";
-import { Interpolation, transform } from "./index";
+import { assert, describe, it } from 'vitest';
+import { Interpolation, transform } from './index';
 
-describe("interpolation", function () {
-  describe("With constructor", () => {
-    it("Simple", () => {
+describe('interpolation', function () {
+  describe('With constructor', () => {
+    it('Simple', () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform("Hello ${name}", {
-          name: "David",
+        interpolation.transform('Hello ${name}', {
+          name: 'David',
         }),
-        "Hello David"
+        'Hello David'
       );
     });
 
-    it("$value", () => {
+    it('$value', () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform("Hello ${$value}", {
-          $value: "David",
+        interpolation.transform('Hello ${$value}', {
+          $value: 'David',
         }),
-        "Hello David"
+        'Hello David'
       );
     });
 
-    it("$value and space", () => {
+    it('$value and space', () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform("Hello ${$value}  ", {
-          $value: "David",
+        interpolation.transform('Hello ${$value}  ', {
+          $value: 'David',
         }),
-        "Hello David  "
+        'Hello David  '
       );
     });
 
-    it("Skippy", () => {
+    it('Skippy', () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform("Hello \\${name}", {
-          name: "David",
+        interpolation.transform('Hello \\${name}', {
+          name: 'David',
         }),
-        "Hello \\${name}"
+        'Hello \\${name}'
       );
     });
 
-    it("Multiple", () => {
+    it('Multiple', () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform("Hello ${firstName} ${lastName}", {
-          firstName: "David",
-          lastName: "Goodenough",
+        interpolation.transform('Hello ${firstName} ${lastName}', {
+          firstName: 'David',
+          lastName: 'Goodenough',
         }),
-        "Hello David Goodenough"
+        'Hello David Goodenough'
       );
     });
 
-    it("Null context property", () => {
+    it('Null context property', () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform("Hello ${firstName} ${lastName}", {
-          firstName: "David",
+        interpolation.transform('Hello ${firstName} ${lastName}', {
+          firstName: 'David',
           lastName: null,
         }),
-        "Hello David "
+        'Hello David '
       );
     });
 
-    it("Missing context property", () => {
+    it('Missing context property', () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform("Hello ${firstName} ${lastName}", {
-          firstName: "David",
+        interpolation.transform('Hello ${firstName} ${lastName}', {
+          firstName: 'David',
         }),
-        "Hello David "
+        'Hello David '
       );
     });
 
-    it("Custom language", () => {
+    it('Custom language', () => {
       const interpolation = new Interpolation({
         customDialects: {
           // eslint-disable-next-line no-useless-escape
@@ -87,44 +87,44 @@ describe("interpolation", function () {
       });
       assert.strictEqual(
         interpolation.transform(
-          "Hello ¤¤firstName¤¤ ¤¤lastName¤¤",
+          'Hello ¤¤firstName¤¤ ¤¤lastName¤¤',
           {
-            firstName: "David",
-            lastName: "Goodenough",
+            firstName: 'David',
+            lastName: 'Goodenough',
           },
-          { dialect: "spider" }
+          { dialect: 'spider' }
         ),
-        "Hello David Goodenough"
+        'Hello David Goodenough'
       );
     });
   });
 
-  describe("With constructor", () => {
-    it("Simple", () => {
+  describe('With constructor', () => {
+    it('Simple', () => {
       assert.strictEqual(
-        transform("Hello ${name}", {
-          name: "David",
+        transform('Hello ${name}', {
+          name: 'David',
         }),
-        "Hello David"
+        'Hello David'
       );
     });
 
-    it("Multiple", () => {
+    it('Multiple', () => {
       assert.strictEqual(
-        transform("Hello ${firstName} ${lastName}", {
-          firstName: "David",
-          lastName: "Goodenough",
+        transform('Hello ${firstName} ${lastName}', {
+          firstName: 'David',
+          lastName: 'Goodenough',
         }),
-        "Hello David Goodenough"
+        'Hello David Goodenough'
       );
     });
   });
 
-  describe("Override default getValue", () => {
-    it("Deep path", () => {
+  describe('Override default getValue', () => {
+    it('Deep path', () => {
       const interpolation = new Interpolation({
         getValue: (ctx, propPath) => {
-          const props = propPath.split(".");
+          const props = propPath.split('.');
           return String(
             props.reduce((prev: any, curr) => {
               return prev[curr];
@@ -134,38 +134,35 @@ describe("interpolation", function () {
       });
 
       assert.strictEqual(
-        interpolation.transform(
-          "Hello ${person.firstName} ${person.lastName}",
-          {
-            person: {
-              firstName: "David",
-              lastName: "Goodenough",
-            },
-          }
-        ),
-        "Hello David Goodenough"
+        interpolation.transform('Hello ${person.firstName} ${person.lastName}', {
+          person: {
+            firstName: 'David',
+            lastName: 'Goodenough',
+          },
+        }),
+        'Hello David Goodenough'
       );
     });
   });
 
-  describe("Case Sensitivity", () => {
-    it("Case sensitive", () => {
+  describe('Case Sensitivity', () => {
+    it('Case sensitive', () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform("Hello ${NaMe}", {
-          name: "David",
+        interpolation.transform('Hello ${NaMe}', {
+          name: 'David',
         }),
-        "Hello "
+        'Hello '
       );
     });
 
-    it("Ignore case", () => {
+    it('Ignore case', () => {
       const interpolation = new Interpolation({ ignoreCase: true });
       assert.strictEqual(
-        interpolation.transform("Hello ${NaMe}", {
-          name: "David",
+        interpolation.transform('Hello ${NaMe}', {
+          name: 'David',
         }),
-        "Hello David"
+        'Hello David'
       );
     });
   });

--- a/packages/belt-interpolation/src/interpolation.spec.ts
+++ b/packages/belt-interpolation/src/interpolation.spec.ts
@@ -1,84 +1,84 @@
 /**
  * @vitest-environment node
  */
-import { describe, it, assert } from 'vitest';
-import { Interpolation, transform } from './index';
+import { assert, describe, it } from "vitest";
+import { Interpolation, transform } from "./index";
 
-describe('interpolation', function () {
-  describe('With constructor', () => {
-    it('Simple', () => {
+describe("interpolation", function () {
+  describe("With constructor", () => {
+    it("Simple", () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform('Hello ${name}', {
-          name: 'David',
+        interpolation.transform("Hello ${name}", {
+          name: "David",
         }),
-        'Hello David'
+        "Hello David"
       );
     });
 
-    it('$value', () => {
+    it("$value", () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform('Hello ${$value}', {
-          $value: 'David',
+        interpolation.transform("Hello ${$value}", {
+          $value: "David",
         }),
-        'Hello David'
+        "Hello David"
       );
     });
 
-    it('$value and space', () => {
+    it("$value and space", () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform('Hello ${$value}  ', {
-          $value: 'David',
+        interpolation.transform("Hello ${$value}  ", {
+          $value: "David",
         }),
-        'Hello David  '
+        "Hello David  "
       );
     });
 
-    it('Skippy', () => {
+    it("Skippy", () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform('Hello \\${name}', {
-          name: 'David',
+        interpolation.transform("Hello \\${name}", {
+          name: "David",
         }),
-        'Hello \\${name}'
+        "Hello \\${name}"
       );
     });
 
-    it('Multiple', () => {
+    it("Multiple", () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform('Hello ${firstName} ${lastName}', {
-          firstName: 'David',
-          lastName: 'Goodenough',
+        interpolation.transform("Hello ${firstName} ${lastName}", {
+          firstName: "David",
+          lastName: "Goodenough",
         }),
-        'Hello David Goodenough'
+        "Hello David Goodenough"
       );
     });
 
-    it('Null context property', () => {
+    it("Null context property", () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform('Hello ${firstName} ${lastName}', {
-          firstName: 'David',
+        interpolation.transform("Hello ${firstName} ${lastName}", {
+          firstName: "David",
           lastName: null,
         }),
-        'Hello David '
+        "Hello David "
       );
     });
 
-    it('Missing context property', () => {
+    it("Missing context property", () => {
       const interpolation = new Interpolation();
       assert.strictEqual(
-        interpolation.transform('Hello ${firstName} ${lastName}', {
-          firstName: 'David',
+        interpolation.transform("Hello ${firstName} ${lastName}", {
+          firstName: "David",
         }),
-        'Hello David '
+        "Hello David "
       );
     });
 
-    it('Custom language', () => {
+    it("Custom language", () => {
       const interpolation = new Interpolation({
         customDialects: {
           // eslint-disable-next-line no-useless-escape
@@ -87,44 +87,44 @@ describe('interpolation', function () {
       });
       assert.strictEqual(
         interpolation.transform(
-          'Hello ¤¤firstName¤¤ ¤¤lastName¤¤',
+          "Hello ¤¤firstName¤¤ ¤¤lastName¤¤",
           {
-            firstName: 'David',
-            lastName: 'Goodenough',
+            firstName: "David",
+            lastName: "Goodenough",
           },
-          { dialect: 'spider' }
+          { dialect: "spider" }
         ),
-        'Hello David Goodenough'
+        "Hello David Goodenough"
       );
     });
   });
 
-  describe('With constructor', () => {
-    it('Simple', () => {
+  describe("With constructor", () => {
+    it("Simple", () => {
       assert.strictEqual(
-        transform('Hello ${name}', {
-          name: 'David',
+        transform("Hello ${name}", {
+          name: "David",
         }),
-        'Hello David'
+        "Hello David"
       );
     });
 
-    it('Multiple', () => {
+    it("Multiple", () => {
       assert.strictEqual(
-        transform('Hello ${firstName} ${lastName}', {
-          firstName: 'David',
-          lastName: 'Goodenough',
+        transform("Hello ${firstName} ${lastName}", {
+          firstName: "David",
+          lastName: "Goodenough",
         }),
-        'Hello David Goodenough'
+        "Hello David Goodenough"
       );
     });
   });
 
-  describe('Override default getValue', () => {
-    it('Deep path', () => {
+  describe("Override default getValue", () => {
+    it("Deep path", () => {
       const interpolation = new Interpolation({
         getValue: (ctx, propPath) => {
-          const props = propPath.split('.');
+          const props = propPath.split(".");
           return String(
             props.reduce((prev: any, curr) => {
               return prev[curr];
@@ -134,17 +134,41 @@ describe('interpolation', function () {
       });
 
       assert.strictEqual(
-        interpolation.transform('Hello ${person.firstName} ${person.lastName}', {
-          person: {
-            firstName: 'David',
-            lastName: 'Goodenough',
-          },
-        }),
-        'Hello David Goodenough'
+        interpolation.transform(
+          "Hello ${person.firstName} ${person.lastName}",
+          {
+            person: {
+              firstName: "David",
+              lastName: "Goodenough",
+            },
+          }
+        ),
+        "Hello David Goodenough"
       );
     });
   });
 
+  describe("Case Sensitivity", () => {
+    it("Case sensitive", () => {
+      const interpolation = new Interpolation();
+      assert.strictEqual(
+        interpolation.transform("Hello ${NaMe}", {
+          name: "David",
+        }),
+        "Hello "
+      );
+    });
+
+    it("Ignore case", () => {
+      const interpolation = new Interpolation({ ignoreCase: true });
+      assert.strictEqual(
+        interpolation.transform("Hello ${NaMe}", {
+          name: "David",
+        }),
+        "Hello David"
+      );
+    });
+  });
   // describe.only('RawTransform', () => {
   //   it('Simple', () => {
   //     const interpolation = new Interpolation();

--- a/packages/belt-interpolation/src/interpolation.ts
+++ b/packages/belt-interpolation/src/interpolation.ts
@@ -11,7 +11,7 @@ export type InterpolationConfig = {
 /** Interpolation transform options */
 export type InterpolationOptions = {
   /** Dialect, by default ECMAScript */
-  dialect?: "ECMAScript" | string;
+  dialect?: 'ECMAScript' | string;
 };
 
 /**
@@ -23,11 +23,7 @@ export class Interpolation {
     ECMAScript: /(\\{0,1})\${([\$\w_\.\-]{1,})}/,
   };
 
-  private readonly _getValue: (
-    ctx: unknown,
-    propPath: string,
-    ...other: string[]
-  ) => string;
+  private readonly _getValue: (ctx: unknown, propPath: string, ...other: string[]) => string;
 
   constructor(
     private readonly _config: InterpolationConfig = {
@@ -38,7 +34,7 @@ export class Interpolation {
       this._config.customDialects = {};
     }
     this._getValue =
-      this._config.getValue ?? this._config.ignoreCase
+      (this._config.getValue ?? this._config.ignoreCase)
         ? Interpolation._ignoreCaseGetValue
         : Interpolation._defaultGetValue;
   }
@@ -53,18 +49,16 @@ export class Interpolation {
   ): string {
     options = options ?? {};
     context = context ?? ({} as C);
-    const dialectName = options.dialect || "ECMAScript";
+    const dialectName = options.dialect || 'ECMAScript';
 
     const dialect =
       dialectName in this._config.customDialects!
         ? this._config.customDialects![dialectName]
         : dialectName in Interpolation._DEFAULT_DIALECTS
-        ? (Interpolation._DEFAULT_DIALECTS as Record<string, RegExp>)[
-            dialectName
-          ]
-        : null;
+          ? (Interpolation._DEFAULT_DIALECTS as Record<string, RegExp>)[dialectName]
+          : null;
     if (dialect) {
-      const re = new RegExp(dialect, "g");
+      const re = new RegExp(dialect, 'g');
 
       return text.replace(re, (substring: string, ...params: string[]) => {
         if (!params[0]) {
@@ -90,18 +84,16 @@ export class Interpolation {
   ): unknown[] {
     options = options ?? {};
     context = context ?? ({} as C);
-    const dialectName = options.dialect || "ECMAScript";
+    const dialectName = options.dialect || 'ECMAScript';
 
     const dialect =
       dialectName in this._config.customDialects!
         ? this._config.customDialects![dialectName]
         : dialectName in Interpolation._DEFAULT_DIALECTS
-        ? (Interpolation._DEFAULT_DIALECTS as Record<string, RegExp>)[
-            dialectName
-          ]
-        : null;
+          ? (Interpolation._DEFAULT_DIALECTS as Record<string, RegExp>)[dialectName]
+          : null;
     if (dialect) {
-      const re = new RegExp(dialect, "g");
+      const re = new RegExp(dialect, 'g');
       const results: unknown[] = [];
 
       text.replace(re, (substring: string, ...params: string[]) => {
@@ -110,7 +102,7 @@ export class Interpolation {
         } else {
           results.push(substring);
         }
-        return "";
+        return '';
       });
       return results;
     } else {
@@ -122,11 +114,8 @@ export class Interpolation {
 
   /** Default get Value */
   private static _defaultGetValue<C>(ctx: C, propPath: string) {
-    const value =
-      propPath in (ctx as Record<string, unknown>)
-        ? (ctx as Record<string, unknown>)[propPath]
-        : null;
-    return value == null ? "" : String(value);
+    const value = propPath in (ctx as Record<string, unknown>) ? (ctx as Record<string, unknown>)[propPath] : null;
+    return value == null ? '' : String(value);
   }
 
   /** Ignore case get Value */
@@ -137,15 +126,11 @@ export class Interpolation {
         value = ctx[key];
       }
     }
-    return value == null ? "" : String(value);
+    return value == null ? '' : String(value);
   }
 }
 
 /** Tranform with interpolation */
-export function transform<C = Record<string, unknown>>(
-  text: string,
-  context: C,
-  options?: InterpolationOptions
-) {
+export function transform<C = Record<string, unknown>>(text: string, context: C, options?: InterpolationOptions) {
   return new Interpolation().transform<C>(text, context, options);
 }

--- a/packages/belt-interpolation/src/interpolation.ts
+++ b/packages/belt-interpolation/src/interpolation.ts
@@ -4,12 +4,14 @@ export type InterpolationConfig = {
   customDialects?: Record<string, RegExp>;
   /** You can overide the default get value */
   getValue?: (ctx: unknown, propPath: string, ...other: string[]) => string;
+  /** Ignore case when matching variables */
+  ignoreCase?: boolean;
 };
 
 /** Interpolation transform options */
 export type InterpolationOptions = {
   /** Dialect, by default ECMAScript */
-  dialect?: 'ECMAScript' | string;
+  dialect?: "ECMAScript" | string;
 };
 
 /**
@@ -21,7 +23,11 @@ export class Interpolation {
     ECMAScript: /(\\{0,1})\${([\$\w_\.\-]{1,})}/,
   };
 
-  private readonly _getValue: (ctx: unknown, propPath: string, ...other: string[]) => string;
+  private readonly _getValue: (
+    ctx: unknown,
+    propPath: string,
+    ...other: string[]
+  ) => string;
 
   constructor(
     private readonly _config: InterpolationConfig = {
@@ -31,7 +37,10 @@ export class Interpolation {
     if (!this._config.customDialects) {
       this._config.customDialects = {};
     }
-    this._getValue = this._config.getValue ?? Interpolation._defaultGetValue;
+    this._getValue =
+      this._config.getValue ?? this._config.ignoreCase
+        ? Interpolation._ignoreCaseGetValue
+        : Interpolation._defaultGetValue;
   }
 
   /** Tranform with interpolation */
@@ -44,16 +53,18 @@ export class Interpolation {
   ): string {
     options = options ?? {};
     context = context ?? ({} as C);
-    const dialectName = options.dialect || 'ECMAScript';
+    const dialectName = options.dialect || "ECMAScript";
 
     const dialect =
       dialectName in this._config.customDialects!
         ? this._config.customDialects![dialectName]
         : dialectName in Interpolation._DEFAULT_DIALECTS
-          ? (Interpolation._DEFAULT_DIALECTS as Record<string, RegExp>)[dialectName]
-          : null;
+        ? (Interpolation._DEFAULT_DIALECTS as Record<string, RegExp>)[
+            dialectName
+          ]
+        : null;
     if (dialect) {
-      const re = new RegExp(dialect, 'g');
+      const re = new RegExp(dialect, "g");
 
       return text.replace(re, (substring: string, ...params: string[]) => {
         if (!params[0]) {
@@ -79,16 +90,18 @@ export class Interpolation {
   ): unknown[] {
     options = options ?? {};
     context = context ?? ({} as C);
-    const dialectName = options.dialect || 'ECMAScript';
+    const dialectName = options.dialect || "ECMAScript";
 
     const dialect =
       dialectName in this._config.customDialects!
         ? this._config.customDialects![dialectName]
         : dialectName in Interpolation._DEFAULT_DIALECTS
-          ? (Interpolation._DEFAULT_DIALECTS as Record<string, RegExp>)[dialectName]
-          : null;
+        ? (Interpolation._DEFAULT_DIALECTS as Record<string, RegExp>)[
+            dialectName
+          ]
+        : null;
     if (dialect) {
-      const re = new RegExp(dialect, 'g');
+      const re = new RegExp(dialect, "g");
       const results: unknown[] = [];
 
       text.replace(re, (substring: string, ...params: string[]) => {
@@ -97,7 +110,7 @@ export class Interpolation {
         } else {
           results.push(substring);
         }
-        return '';
+        return "";
       });
       return results;
     } else {
@@ -109,12 +122,30 @@ export class Interpolation {
 
   /** Default get Value */
   private static _defaultGetValue<C>(ctx: C, propPath: string) {
-    const value = propPath in (ctx as Record<string, unknown>) ? (ctx as Record<string, unknown>)[propPath] : null;
-    return value == null ? '' : String(value);
+    const value =
+      propPath in (ctx as Record<string, unknown>)
+        ? (ctx as Record<string, unknown>)[propPath]
+        : null;
+    return value == null ? "" : String(value);
+  }
+
+  /** Ignore case get Value */
+  private static _ignoreCaseGetValue<C>(ctx: C, propPath: string) {
+    let value = null;
+    for (const key in ctx) {
+      if (key.toLowerCase() === propPath.toLowerCase()) {
+        value = ctx[key];
+      }
+    }
+    return value == null ? "" : String(value);
   }
 }
 
 /** Tranform with interpolation */
-export function transform<C = Record<string, unknown>>(text: string, context: C, options?: InterpolationOptions) {
+export function transform<C = Record<string, unknown>>(
+  text: string,
+  context: C,
+  options?: InterpolationOptions
+) {
   return new Interpolation().transform<C>(text, context, options);
 }


### PR DESCRIPTION
fixes #53 

This adds a new config option `ignoreCase` which, when true, will allow replacing variables regardless of case.
example:
```typescript
const interpolation = new Interpolation({ ignoreCase: true });
interpolation.transform("Hello ${NaMe}", {
  name: "David",
})
```